### PR TITLE
🐛 :: apply korea time

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -5,9 +5,12 @@
         <div class="mt:16 f:fade-60">
             {{- if isset .Params "date" -}}
             {{ if eq .Lastmod .Date }}
-            <time>{{ .Date | time.Format (":date_medium") }}</time>
+            <!-- <time>{{ .Date | time.Format (":date_medium") }}</time>
             {{ else }}
-            <time>{{ .Lastmod | time.Format (":date_medium") }}</time>
+            <time>{{ .Lastmod | time.Format (":date_medium") }}</time> -->
+            <time datetime="{{ .Date }}">{{ .Date.Format "2006년 1월 2일" }}</time>
+            {{- else if .Lastmod -}}
+            <time datetime="{{ .Lastmod }}">{{ .Lastmod.Format "2006년 1월 2일" }}</time>
             {{ end }}
             {{- end -}}
         </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,22 @@
+{
+  "name": "holy",
+  "version": "0.0.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "holy",
+      "version": "0.0.1",
+      "license": "ISC",
+      "dependencies": {
+        "holy": "^0.0.0"
+      }
+    },
+    "node_modules/holy": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/holy/-/holy-0.0.0.tgz",
+      "integrity": "sha512-R/f3DOdpe+pKc+8wMKLUSHKzOiH4Uo6KznHnFP6eWrtr15RDPA8sdI+gmp4wQxPIuhjrrp1gBEVBIXKpq70RIA==",
+      "license": "GPL-2.0"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -16,5 +16,8 @@
   "bugs": {
     "url": "https://github.com/serkodev/holy/issues"
   },
-  "homepage": "https://github.com/serkodev/holy#readme"
+  "homepage": "https://github.com/serkodev/holy#readme",
+  "dependencies": {
+    "holy": "^0.0.0"
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,3 +2,7 @@
 # yarn lockfile v1
 
 
+holy@^0.0.0:
+  version "0.0.0"
+  resolved "https://registry.npmjs.org/holy/-/holy-0.0.0.tgz"
+  integrity sha512-R/f3DOdpe+pKc+8wMKLUSHKzOiH4Uo6KznHnFP6eWrtr15RDPA8sdI+gmp4wQxPIuhjrrp1gBEVBIXKpq70RIA==


### PR DESCRIPTION
Hello, I'm a user who uses your Hugo service holly. I noticed a problem while using the theme holly. In Korean time, when I wrote a blog and built it, I had a problem that said:date_medium. To solve this problem, instead of the value:date_medium 
```    
<time datetime="{{ .Date }}">{{ .Date.Format "2006년 1월 2일" }}</time>
                {{- else if .Lastmod -}}
                <time datetime="{{ .Lastmod }}">{{ .Lastmod.Format "2006년 1월 2일" }}</time>
```
It needs to be set in Korean like this.

It was different from the Hugo version you defined in vercel and netilfy, which are the vape tools you often use in your second routine. In other words, it wasn't the latest version. I solve this problem. 

Thank you for making a simple design blog template holi.